### PR TITLE
Setting up use of dotenv for development

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,4 @@
+# https://developer.bigcommerce.com/docs/ZG9jOjIyMDYxMw-v2-and-v3-rest-api-authentication#api-accounts
+
+STORE_HASH=STORE_HASH
+ACCESS_TOKEN=ACCESS_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.env
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
     faraday (2.5.2)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -63,6 +64,7 @@ PLATFORMS
 
 DEPENDENCIES
   bigcommerce-v3!
+  dotenv (~> 2.8)
   rspec (~> 3.0)
   rubocop (~> 1.21)
   rubocop-performance

--- a/README.md
+++ b/README.md
@@ -103,11 +103,17 @@ products.data[0]
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/rspec` to run the tests.
 
 To install this gem onto your local machine, run `bundle exec rake install`. 
 
 To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### Using bin/console
+
+You can run `bin/console` for an interactive prompt that will allow you to experiment.
+
+Copy and rename `.env.template` to `.env` and update with your `STORE_HASH` and `ACCESS_TOKEN` before launching console.
 
 ## Contributing
 

--- a/bigcommerce-v3.gemspec
+++ b/bigcommerce-v3.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 2.5.2'
   spec.add_dependency 'rake', '~> 13.0'
 
+  spec.add_development_dependency 'dotenv', '~> 2.8'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.21'
   spec.add_development_dependency 'rubocop-performance'

--- a/bin/console
+++ b/bin/console
@@ -1,15 +1,35 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Set BIGCOMMERCE_V3_ENV so that dotenv is initialized
+ENV['BIGCOMMERCE_V3_ENV'] = 'development'
+
 require 'bundler/setup'
 require 'bigcommerce/v3'
-
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require 'irb'
+
+# Create a Bigcommerce::V3::Configuration object with .env variables
+@config = Bigcommerce::V3::Configuration.new(store_hash: ENV.fetch('STORE_HASH', nil),
+                                             access_token: ENV.fetch('ACCESS_TOKEN', nil),
+                                             logger: true)
+
+# Create a Bigcommerce::V3::Client
+@client = Bigcommerce::V3::Client.new(config: @config)
+
+# Print to console
+puts '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+puts 'BigCommerce V3 HTTP API Client Console'
+puts "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n"
+puts 'Variables:'
+puts '~~~~~~~~~~'
+puts "- ENV['BIGCOMMERCE_V3_ENV']: #{ENV.fetch('BIGCOMMERCE_V3_ENV', nil)}"
+puts "- ENV['STORE_HASH']: #{ENV.fetch('STORE_HASH', nil)}"
+puts "- ENV['ACCESS_TOKEN']: [REDACTED]"
+puts "- @client = Bigcommerce::V3::Client\n\n"
+puts 'Example usage:'
+puts '~~~~~~~~~~~~~~'
+puts "@client.customers.list\n  # Returns first page of Customers"
+puts "@client.pages.list\n  # Returns first page of Pages\n\n"
+
+# Start IRB
 IRB.start(__FILE__)

--- a/lib/bigcommerce/v3.rb
+++ b/lib/bigcommerce/v3.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+##
+# Load dotenv only in development or test environment
+if %w[development test].include? ENV['BIGCOMMERCE_V3_ENV']
+  require 'dotenv/load'
+  Dotenv.require_keys('STORE_HASH', 'ACCESS_TOKEN')
+end
+
 require 'faraday'
 
 require 'bigcommerce/v3/version'


### PR DESCRIPTION
Updated gemspec to include dotenv for testing/development
Updated v3.rb to require and initialize dotenv if ENV['BIGCOMMERCE_V3_ENV'] is set to 'development'/'test'
Created template .env
Updated console to pull from ENV['STORE_HASH'] and ENV['ACCESS_TOKEN']
Updated console with descriptive output
Updated Readme

<img width="842" alt="Screen Shot 2022-09-03 at 1 30 30 AM" src="https://user-images.githubusercontent.com/7632624/188259014-c92825ff-476f-4e1f-b0e9-75223abb7083.png">
