### PR TITLE
Finishing up non bulk api .retrieve spec extraction into shared_examples

### DIFF
--- a/lib/bigcommerce/v3/api_actions/retrieve.rb
+++ b/lib/bigcommerce/v3/api_actions/retrieve.rb
@@ -25,6 +25,10 @@ module Bigcommerce
         def params_for_retrieve(id:, params:)
           params
         end
+
+        def url_for_retrieve(id:)
+          "#{base_url}#{resource_url}/#{id}"
+        end
       end
     end
   end

--- a/lib/bigcommerce/v3/resources/marketing/abandoned_cart_emails/abandoned_cart_email_settings.rb
+++ b/lib/bigcommerce/v3/resources/marketing/abandoned_cart_emails/abandoned_cart_email_settings.rb
@@ -26,7 +26,8 @@ module Bigcommerce
       end
 
       def params_for_retrieve(id:, params:)
-        { channel_id: id }
+        params[:channel_id] = id
+        params
       end
 
       ##

--- a/spec/bigcommerce/v3/resources/catalog/category_trees_resource_spec.rb
+++ b/spec/bigcommerce/v3/resources/catalog/category_trees_resource_spec.rb
@@ -21,13 +21,14 @@ describe 'Bigcommerce::V3::CategoryTreesResource' do
   end
 
   describe '#list' do
-    let(:resource_action) { 'list' }
-    let(:status) { 200 }
-
     it_behaves_like 'a .list endpoint'
   end
 
   describe '#retrieve' do
+    # Has unique behavior from other endpoints
+    # The .retrieve endpoint is "#{base_url}#{resource_url}/#{id}/categories"
+    # and the returned record has a hash of all the categories in that tree,
+    # as opposed to a tree record
     subject(:response) { resource.retrieve(id: id) }
 
     let(:resource_action) { 'retrieve' }
@@ -35,6 +36,8 @@ describe 'Bigcommerce::V3::CategoryTreesResource' do
     let(:stubs) { stub_request(path: url, response: stubbed_response) }
     let(:status) { 200 }
     let(:id) { 1 }
+    let(:retrieve_invalid_id_status) { 404 }
+    let(:retrieve_url) { "#{base_url}#{resource_url}/#{id}/categories" }
 
     context 'when the record exists' do
       let(:status) { 200 }
@@ -44,10 +47,16 @@ describe 'Bigcommerce::V3::CategoryTreesResource' do
       it { is_expected.to be_success }
 
       it 'returns an array with the record' do
+        # Has unique behavior from other endpoints
+        # Returns all of the elements of the category tree
+        # instead of a single object
         expect(returned_records.count).to be > 0
       end
 
-      it 'returns an array of Bigcommerce::V3::AbandonedCartEmail records' do
+      it 'returns an array of records as objects' do
+        # Has unique behavior from other endpoints
+        # Returns all of the elements of the category tree
+        # instead of a single object
         expect(returned_records).to all(be_an(object_type))
       end
     end

--- a/spec/bigcommerce/v3/resources/marketing/abandoned_cart_emails/abandoned_cart_email_settings_resource_spec.rb
+++ b/spec/bigcommerce/v3/resources/marketing/abandoned_cart_emails/abandoned_cart_email_settings_resource_spec.rb
@@ -21,9 +21,13 @@ describe 'Bigcommerce::V3::AbandonedCartEmailSettingsResource' do
   end
 
   describe '#retrieve' do
+    # Has unique behavior from other endpoints
+    # The returned record does not contain an ID and thus
+    # verifying is tricky
     let(:stubs) { stub_request(path: url, response: stubbed_response) }
     let(:response) { resource.retrieve(id: id) }
     let(:resource_action) { 'retrieve' }
+    let(:retrieve_invalid_id_status) { 422 }
 
     context 'when retrieving a valid id' do
       let(:fixture_file) { status.to_s }

--- a/spec/bigcommerce/v3/resources/marketing/abandoned_cart_emails_resource_spec.rb
+++ b/spec/bigcommerce/v3/resources/marketing/abandoned_cart_emails_resource_spec.rb
@@ -23,81 +23,14 @@ describe 'Bigcommerce::V3::AbandonedCartEmailsResource' do
   end
 
   describe '#list' do
-    let(:resource_action) { 'list' }
-    let(:status) { 200 }
-
     it_behaves_like 'a .list endpoint'
   end
 
   describe '#retrieve' do
-    subject(:response) { resource.retrieve(id: id) }
+    let(:retrieve_invalid_id_status) { 404 }
+    let(:retrieve_url) { "#{base_url}#{resource_url}/#{id}" }
 
-    let(:resource_action) { 'retrieve' }
-    let(:status) { 200 }
-    let(:stubs) { stub_request(path: url, response: stubbed_response) }
-    let(:url) { "#{base_url}#{resource_url}/#{id}" }
-
-    context 'when retrieving a valid id' do
-      let(:status) { 200 }
-      let(:fixture_file) { status.to_s }
-      let(:id) { 2 }
-
-      it { is_expected.to be_a(Bigcommerce::V3::Response) }
-      it { is_expected.to be_success }
-
-      it 'stores an array with 1 returned record' do
-        expect(returned_records.count).to eq(1)
-      end
-
-      it 'returns the correct customer_id record' do
-        expect(returned_record.id).to eq(id)
-      end
-    end
-
-    context 'when retrieving a non-existent id' do
-      let(:fixture_file) { status.to_s }
-      let(:id) { 42 }
-      let(:status) { 404 }
-
-      it { is_expected.to be_a(Bigcommerce::V3::Response) }
-      it { is_expected.not_to be_success }
-
-      it 'returns a nil .data' do
-        expect(returned_records).to be_nil
-      end
-    end
-
-    context 'when called with invalid :id types' do
-      let(:fixture) { '' }
-
-      invalid_id_examples = [nil, 'string', 0, [1, 2], { a: 1 }] # nil, string, <1, array, hash
-
-      invalid_id_examples.each do |id|
-        let(:id) { URI.encode_www_form(id) }
-
-        it 'raises a Bigcommerce::V3::Error' do
-          expect { response }.to raise_error(Bigcommerce::V3::Error::InvalidArguments)
-        end
-      end
-    end
-
-    context 'when called with invalid :params types' do
-      subject(:response) { resource.retrieve(id: id, params: params) }
-
-      let(:fixture) { '' }
-      let(:id) { 1 }
-
-      invalid_params_examples = [nil, 'string', 0, [1, 2]] # nil, string, integer, array
-
-      invalid_params_examples.each do |param|
-        let(:params) { param }
-        let(:stringified_params) { param.to_json }
-
-        it 'raises a Bigcommerce::V3::Error' do
-          expect { response }.to raise_error(Bigcommerce::V3::Error::InvalidArguments)
-        end
-      end
-    end
+    it_behaves_like 'a .retrieve endpoint'
   end
 
   describe '#create' do

--- a/spec/bigcommerce/v3/resources/wishlists_resource_spec.rb
+++ b/spec/bigcommerce/v3/resources/wishlists_resource_spec.rb
@@ -26,15 +26,13 @@ describe 'Bigcommerce::V3::WishlistsResource' do
 
     it_behaves_like 'a .list endpoint'
   end
-  #
-  # describe '#retrieve' do
-  #   let(:status) { 200 }
-  #   let(:retrieve_no_records_status) { 200 }
-  #   let(:retrieve_invalid_id_status) { 422 }
-  #   let(:retrieve_optional_params) { { include: 'storecredit' } }
-  #
-  #   it_behaves_like 'a bulk .retrieve endpoint'
-  # end
+
+  describe '#retrieve' do
+    let(:retrieve_invalid_id_status) { 404 }
+    let(:retrieve_url) { "#{base_url}#{resource_url}/#{id}" }
+
+    it_behaves_like 'a .retrieve endpoint'
+  end
   #
   # describe '#create' do
   #   let(:single_record_params) do

--- a/spec/fixtures/resources/wishlists/retrieve/200.json
+++ b/spec/fixtures/resources/wishlists/retrieve/200.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": 1,
+    "id": 2,
     "customer_id": 84,
     "name": "My Favorite List",
     "is_public": true,

--- a/spec/fixtures/resources/wishlists/retrieve/404.json
+++ b/spec/fixtures/resources/wishlists/retrieve/404.json
@@ -1,0 +1,6 @@
+{
+  "status": 404,
+  "title": "Could not find wishlist",
+  "type": "https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes",
+  "errors": {}
+}

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -8,6 +8,7 @@ require './spec/support/shared_examples/resources/base'
 
 # Resources
 require './spec/support/shared_examples/resources/list'
+require './spec/support/shared_examples/resources/retrieve'
 
 # Bulk Resources
 require './spec/support/shared_examples/resources/bulk/bulk_create'

--- a/spec/support/shared_examples/resources/retrieve.rb
+++ b/spec/support/shared_examples/resources/retrieve.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a .retrieve endpoint' do
+  subject(:response) { resource.retrieve(id: id) }
+
+  let(:resource_action) { 'retrieve' }
+  let(:status) { 200 }
+  let(:stubs) { stub_request(path: url, response: stubbed_response) }
+  let(:url) { retrieve_url }
+
+  context 'when passed a valid id' do
+    let(:status) { 200 }
+    let(:fixture_file) { status.to_s }
+    let(:id) { 2 }
+
+    it { is_expected.to be_a(Bigcommerce::V3::Response) }
+    it { is_expected.to be_success }
+
+    it 'returns an array with 1 record' do
+      expect(returned_records.count).to eq(1)
+    end
+
+    it 'returns the correct record id' do
+      expect(returned_record.id).to eq(id)
+    end
+  end
+
+  context 'when passed a non-existent id' do
+    let(:fixture_file) { status.to_s }
+    let(:id) { 42 }
+    let(:status) { retrieve_invalid_id_status }
+
+    it { is_expected.to be_a(Bigcommerce::V3::Response) }
+    it { is_expected.not_to be_success }
+
+    it 'returns a nil .data' do
+      expect(returned_records).to be_nil
+    end
+  end
+
+  context 'when called with invalid :id types' do
+    let(:fixture) { '' }
+
+    invalid_id_examples = [nil, 'string', 0, [1, 2], { a: 1 }] # nil, string, <1, array, hash
+
+    invalid_id_examples.each do |id|
+      let(:id) { URI.encode_www_form(id) }
+
+      it 'raises a Bigcommerce::V3::Error' do
+        expect { response }.to raise_error(Bigcommerce::V3::Error::InvalidArguments)
+      end
+    end
+  end
+
+  context 'when called with invalid :params types' do
+    subject(:response) { resource.retrieve(id: id, params: params) }
+
+    let(:fixture) { '' }
+    let(:id) { 1 }
+
+    invalid_params_examples = [nil, 'string', 0, [1, 2]] # nil, string, integer, array
+
+    invalid_params_examples.each do |param|
+      let(:params) { param }
+      let(:stringified_params) { param.to_json }
+
+      it 'raises a Bigcommerce::V3::Error' do
+        expect { response }.to raise_error(Bigcommerce::V3::Error::InvalidArguments)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Extracted url_for_retrieve from .retrieve since different endpoints use different formats. Ex: CategoryTrees uses /resource_url/:id/categories
* Fixed abandoned cart email settings params for retrieve to include passed in params
* Cleaned up unnecessary spec variables
* Added comment to CategoryTreesResource spec that .retrieve has unique behavior
* Extracted url and invalid_id_status for non bulk specs
* Added comment to AbandonedCartEmailSettingsResource spec that .retrieve has unique behavior
* Simplified AbandonedCartEmailsResource by extracting .retrieve specs
* Simplified  WishlistsResource by extracting .retrieve specs

closes #36 